### PR TITLE
Added A10 to exporters.md

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -58,6 +58,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Twemproxy](https://github.com/stuartnelson3/twemproxy_exporter)
 
 ### Hardware related
+   * [A10 Thunder exporter](https://github.com/a10networks/PrometheusExporter)
    * [apcupsd exporter](https://github.com/mdlayher/apcupsd_exporter)
    * [BIG-IP exporter](https://github.com/ExpressenAB/bigip_exporter)
    * [Collins exporter](https://github.com/soundcloud/collins_exporter)
@@ -236,6 +237,7 @@ possible.
 Some third-party software exposes metrics in the Prometheus format, so no
 separate exporters are needed:
 
+   * [A10 Thunder](https://www.a10networks.com/)
    * [Ansible Tower (AWX)](https://docs.ansible.com/ansible-tower/latest/html/administration/metrics.html)
    * [App Connect Enterprise](https://github.com/ot4i/ace-docker)
    * [Ballerina](https://ballerina.io/)


### PR DESCRIPTION
Added a link in the 'Exporters' section for using the A10 exporter for older version of Thunder software.
Added a link in the 'metrics' section for using the native support in A10 Thunder. NOTE: This just links to the A10 main webpage currently. If we add something specific for Prometheus, I'll come back and change this.